### PR TITLE
Potential fix for code scanning alert no. 17: Reflected cross-site scripting

### DIFF
--- a/services/hiveoview/src/views/tile/renderTileSourceRow.go
+++ b/services/hiveoview/src/views/tile/renderTileSourceRow.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hiveot/hub/lib/utils"
 	"github.com/hiveot/hub/services/hiveoview/src/session"
 	"net/http"
+	"html"
 )
 
 // RenderTileSourceRow renders a single table row with the tile 'source'
@@ -89,7 +90,7 @@ func RenderTileSourceRow(w http.ResponseWriter, r *http.Request) {
 		"  <div>%s</div>"+
 		"  <div>%s</div>"+
 		"</li>",
-		sourceID, title, sourceID, latestValue, latestUpdated)
+		html.EscapeString(sourceID), html.EscapeString(title), html.EscapeString(sourceID), html.EscapeString(latestValue), html.EscapeString(latestUpdated))
 
 	_, _ = w.Write([]byte(htmlToAdd))
 	return


### PR DESCRIPTION
Potential fix for [https://github.com/hiveot/hub/security/code-scanning/17](https://github.com/hiveot/hub/security/code-scanning/17)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the user input before embedding it into the HTML response. In Go, the `html` package provides the `EscapeString` function, which can be used to escape special characters in a string to their corresponding HTML entities. This will prevent any malicious scripts from being executed in the user's browser.

The best way to fix the problem is to use `html.EscapeString` on the `sourceID`, `title`, and other user-controlled variables before embedding them into the HTML response. This ensures that any special characters are properly escaped, mitigating the risk of XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
