### PR TITLE
Potential fix for code scanning alert no. 28: Reflected cross-site scripting

### DIFF
--- a/services/hiveoview/src/views/history/renderLatestValueRow.go
+++ b/services/hiveoview/src/views/history/renderLatestValueRow.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hiveot/hub/lib/utils"
 	"github.com/hiveot/hub/services/hiveoview/src/session"
 	"net/http"
+	"html"
 )
 
 // Add the latest event value to the history table and to the history chart
@@ -36,7 +37,7 @@ func RenderLatestValueRow(w http.ResponseWriter, r *http.Request) {
 	affType := chi.URLParam(r, "affordanceType")
 	thingID := chi.URLParam(r, "thingID")
 	name := chi.URLParam(r, "name")
-	unit := r.URL.Query().Get("unit")
+	unit := html.EscapeString(r.URL.Query().Get("unit"))
 	fragment := ""
 
 	// Read the TD being displayed and its latest values


### PR DESCRIPTION
Potential fix for [https://github.com/hiveot/hub/security/code-scanning/28](https://github.com/hiveot/hub/security/code-scanning/28)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user-provided input is properly sanitized before being included in the HTML output. In Go, the `html` package provides the `EscapeString` function, which can be used to escape special characters in a string to their corresponding HTML entities.

The best way to fix this issue is to use `html.EscapeString` on the `unit` parameter before including it in the HTML fragment. This will ensure that any potentially malicious input is safely escaped and cannot execute as HTML or JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
